### PR TITLE
Dev/read body

### DIFF
--- a/forward-auth-wasm/src/guest.rs
+++ b/forward-auth-wasm/src/guest.rs
@@ -1,6 +1,6 @@
 // reference code from https://github.com/elisasre/http-wasm-rust/blob/main/src/guest.rs
 use serde::{Deserialize, Serialize};
-use std::{convert::TryInto, str, usize::MAX, vec};
+use std::{str, vec};
 
 pub const FATAL: i32 = 3;
 pub const ERROR: i32 = 2;

--- a/forward-auth-wasm/src/guest.rs
+++ b/forward-auth-wasm/src/guest.rs
@@ -117,8 +117,8 @@ pub fn readbody(kind: i32) -> Vec<u8> {
     //   (param  $buf i32) (param $buf_len i32)
     //   (result (; 0 or EOF(1) << 32 | len ;) i64)))
     let max_buffer_size = 1024 * 1024; // 1 MB buffer
-                                       // let max_buffer_size: usize = usize::MAX;
     let read_buf = vec![0; max_buffer_size];
+
     unsafe {
         let mut eof = 1;
         let mut full_body = Vec::new();
@@ -135,7 +135,7 @@ pub fn readbody(kind: i32) -> Vec<u8> {
             full_body.extend_from_slice(&read_buf[..len as usize]);
         }
 
-        return full_body.to_vec();
+        return full_body;
     };
 }
 

--- a/forward-auth-wasm/src/guest.rs
+++ b/forward-auth-wasm/src/guest.rs
@@ -1,6 +1,6 @@
 // reference code from https://github.com/elisasre/http-wasm-rust/blob/main/src/guest.rs
 use serde::{Deserialize, Serialize};
-use std::str;
+use std::{convert::TryInto, str, usize::MAX, vec};
 
 pub const FATAL: i32 = 3;
 pub const ERROR: i32 = 2;
@@ -13,8 +13,8 @@ pub const RESPONSE_HEADER: i32 = 1;
 pub const REQUEST_HEADER_TRAILERS: i32 = 2;
 pub const RESPONSE_HEADER_TRAILERS: i32 = 3;
 
-pub const REQUEST_BODY: u32 = 0;
-pub const RESPONSE_BODY: u32 = 1;
+pub const REQUEST_BODY: i32 = 0;
+pub const RESPONSE_BODY: i32 = 1;
 
 pub const FEATURE_BUFFER_REQUEST: u32 = 1;
 pub const FEATURE_BUFFER_RESPONSE: u32 = 2;
@@ -79,7 +79,7 @@ extern "C" {
     fn log_enabled(level: i32) -> i32;
 
     // read_body - work in progress
-    fn read_body(body_kind: u32, ptr: *const u8, buf_limit: u32) -> i64;
+    fn read_body(body_kind: i32, ptr: *const i32, buf_limit: i32) -> i64;
 
     // TODO: implement
     fn write_body(body_kind: u32, ptr: *const u8, message_len: u32);
@@ -111,15 +111,31 @@ pub fn enable_feature(feature: u32) -> i32 {
     };
 }
 
-pub fn readbody(kind: u32) -> Vec<u8> {
-    let read_buf: [u8; 2048] = [0; 2048];
+pub fn readbody(kind: i32) -> Vec<u8> {
+    // (import "http_handler" "read_body" (func $read_body
+    //   (param $kind i32)
+    //   (param  $buf i32) (param $buf_len i32)
+    //   (result (; 0 or EOF(1) << 32 | len ;) i64)))
+    let max_buffer_size = 1024 * 1024; // 1 MB buffer
+                                       // let max_buffer_size: usize = usize::MAX;
+    let read_buf = vec![0; max_buffer_size];
     unsafe {
-        match read_body(kind, read_buf.as_ptr(), 2048) {
-            // TODO: how to define the limit?
-            len => {
-                return read_buf[0..len as usize].to_vec();
-            }
+        let mut eof = 1;
+        let mut full_body = Vec::new();
+
+        while eof != 0 {
+            let response = read_body(
+                kind,
+                read_buf.as_ptr() as *const i32,
+                max_buffer_size as i32,
+            );
+            eof = (response << 32) as i32;
+            let len = response as i32;
+
+            full_body.extend_from_slice(&read_buf[..len as usize]);
         }
+
+        return full_body.to_vec();
     };
 }
 

--- a/forward-auth-wasm/src/lib.rs
+++ b/forward-auth-wasm/src/lib.rs
@@ -1,4 +1,4 @@
-use guest::CloudflareConfig;
+use guest::{CloudflareConfig, REQUEST_BODY, RESPONSE_BODY};
 use lazy_static::lazy_static;
 mod guest;
 
@@ -33,8 +33,8 @@ pub fn http_request() -> i64 {
     // let header_values = &guest::get_header_val(guest::REQUEST_HEADER, &header);
     // guest::send_log(guest::DEBUG, format!("{:?}", header_values).as_str());
 
-    let method = &guest::status_code();
-    guest::send_log(guest::DEBUG, format!("{:?}", method).as_str());
+    let data = &guest::readbody(REQUEST_BODY);
+    guest::send_log(guest::INFO, format!("{:?}", data).as_str());
 
     return 16 << 32 | 1 as i64;
 }


### PR DESCRIPTION
This pull request includes significant changes to the `forward-auth-wasm` project, primarily focusing on modifying data types and improving the `readbody` function. The most important changes are listed below:

### Data Type Modifications:

* Changed the data type of several constants from `u32` to `i32` in `forward-auth-wasm/src/guest.rs`. This affects constants such as `REQUEST_BODY` and `RESPONSE_BODY`.
* Updated the `read_body` function signature to use `i32` instead of `u32` for the `body_kind` and `buf_limit` parameters, and changed the pointer type for `ptr` to `*const i32` in `forward-auth-wasm/src/guest.rs`.

### Function Improvements:

* Enhanced the `readbody` function to handle larger data by implementing a loop that reads chunks of data until EOF is reached, and increased the buffer size to 1 MB in `forward-auth-wasm/src/guest.rs`.

### Code Import Adjustments:

* Added `vec` to the import statement to support vector operations in `forward-auth-wasm/src/guest.rs`.
* Updated imports in `forward-auth-wasm/src/lib.rs` to include `REQUEST_BODY` and `RESPONSE_BODY` from the `guest` module.

### Logging and Data Handling:

* Modified the `http_request` function to log the body data read using the updated `readbody` function, replacing the previous status code logging in `forward-auth-wasm/src/lib.rs`.