### PR TITLE
added enable_feature support

### DIFF
--- a/forward-auth-wasm/src/guest.rs
+++ b/forward-auth-wasm/src/guest.rs
@@ -16,9 +16,9 @@ pub const RESPONSE_HEADER_TRAILERS: i32 = 3;
 pub const REQUEST_BODY: i32 = 0;
 pub const RESPONSE_BODY: i32 = 1;
 
-pub const FEATURE_BUFFER_REQUEST: u32 = 1;
-pub const FEATURE_BUFFER_RESPONSE: u32 = 2;
-pub const FEATURE_TRAILERS: u32 = 3;
+pub const FEATURE_BUFFER_REQUEST: i32 = 1;
+pub const FEATURE_BUFFER_RESPONSE: i32 = 2;
+pub const FEATURE_TRAILERS: i32 = 4;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CloudflareConfig {
@@ -78,7 +78,7 @@ extern "C" {
     // TODO: implement
     fn log_enabled(level: i32) -> i32;
 
-    // read_body - work in progress
+    // read_body working
     fn read_body(body_kind: i32, ptr: *const i32, buf_limit: i32) -> i64;
 
     // TODO: implement
@@ -88,8 +88,8 @@ extern "C" {
     fn get_status_code() -> i32;
     // TODO: implement
     fn set_status_code(code: i32);
-    // TODO: implement
-    fn enable_features(feature: u32) -> i32;
+    // working with enable_features
+    fn enable_features(feature: i32) -> i32;
     // working with get source address
     fn get_source_addr(buf: *const i32, buf_limit: i32) -> i32;
 }
@@ -101,7 +101,12 @@ pub fn status_code() -> i32 {
     unsafe { return get_status_code() };
 }
 
-pub fn enable_feature(feature: u32) -> i32 {
+pub fn enable_feature(feature: i32) -> i32 {
+    // ;; enable_features tries to enable the given features and returns the entire
+    // ;; feature bitflag supported by the host.
+    // (import "http_handler" "enable_features" (func $enable_features
+    //   (param $enable_features i32)
+    //   (result  (; features ;) i32)))
     unsafe {
         match enable_features(feature) {
             res => {

--- a/forward-auth-wasm/src/lib.rs
+++ b/forward-auth-wasm/src/lib.rs
@@ -33,8 +33,9 @@ pub fn http_request() -> i64 {
     // let header_values = &guest::get_header_val(guest::REQUEST_HEADER, &header);
     // guest::send_log(guest::DEBUG, format!("{:?}", header_values).as_str());
 
-    let data = &guest::readbody(REQUEST_BODY);
-    guest::send_log(guest::INFO, format!("{:?}", data).as_str());
+    // let data = &guest::readbody(REQUEST_BODY);
+    let features = &guest::enable_feature(guest::FEATURE_BUFFER_REQUEST);
+    guest::send_log(guest::WARN, format!("{:?}", features).as_str());
 
     return 16 << 32 | 1 as i64;
 }


### PR DESCRIPTION
This pull request includes several changes to the `forward-auth-wasm` project, focusing on modifying constants and function signatures to use `i32` instead of `u32`, and updating the logging and feature enabling mechanisms. The most important changes are summarized below:

### Changes to constants and function signatures:

* Changed the type of `FEATURE_BUFFER_REQUEST`, `FEATURE_BUFFER_RESPONSE`, and `FEATURE_TRAILERS` constants from `u32` to `i32` in `forward-auth-wasm/src/guest.rs`. (`[forward-auth-wasm/src/guest.rsL19-R21](diffhunk://#diff-a05cca784d0cf768c7daea9427a9565f0ed99e6660d62b9a579a0059c7ebc94eL19-R21)`)
* Updated the `enable_features` function signature to use `i32` instead of `u32` in `extern "C"` block in `forward-auth-wasm/src/guest.rs`. (`[forward-auth-wasm/src/guest.rsL91-R92](diffhunk://#diff-a05cca784d0cf768c7daea9427a9565f0ed99e6660d62b9a579a0059c7ebc94eL91-R92)`)
* Modified the `enable_feature` function to accept an `i32` parameter instead of `u32` in `forward-auth-wasm/src/guest.rs`. (`[forward-auth-wasm/src/guest.rsL104-R109](diffhunk://#diff-a05cca784d0cf768c7daea9427a9565f0ed99e6660d62b9a579a0059c7ebc94eL104-R109)`)

### Logging and feature enabling updates:

* Updated the comment for the `read_body` function to indicate it is now working in `extern "C"` block in `forward-auth-wasm/src/guest.rs`. (`[forward-auth-wasm/src/guest.rsL81-R81](diffhunk://#diff-a05cca784d0cf768c7daea9427a9565f0ed99e6660d62b9a579a0059c7ebc94eL81-R81)`)
* Modified the `http_request` function to log the enabled features instead of reading the request body in `forward-auth-wasm/src/lib.rs`. (`[forward-auth-wasm/src/lib.rsL36-R38](diffhunk://#diff-3be3d7e5b2acc1cbf69896093481cf13a79f2b3ac1943779779fec6275838a35L36-R38)`)