### PR TITLE
Dev/add header value

### DIFF
--- a/forward-auth-wasm/src/guest.rs
+++ b/forward-auth-wasm/src/guest.rs
@@ -43,13 +43,13 @@ extern "C" {
     fn set_uri(ptr: *const u8, message_len: u32);
     // working get_protocol_version
     fn get_protocol_version(ptr: *const i32, message_len: i32) -> i32;
-    // TODO: implement
+    // working add_header_value
     fn add_header_value(
-        header_kind: u32,
-        name_ptr: *const u8,
-        name_len: u32,
-        value_ptr: *const u8,
-        value_len: u32,
+        header_kind: i32,
+        name_ptr: *const i32,
+        name_len: i32,
+        value_ptr: *const i32,
+        value_len: i32,
     );
     // TODO: implement
     fn set_header_value(
@@ -255,14 +255,23 @@ pub fn set_header(kind: u32, name: &str, value: &str) {
     };
 }
 
-pub fn add_header(kind: u32, name: &str, value: &str) {
+pub fn add_header(kind: i32, name: &str, value: &str) {
+    // ;; add_header_value adds a single value for the given header name.
+    // ;;
+    // ;; Note: A host who fails to add the header will trap (aka panic,
+    // ;; "unreachable" instruction).
+    // (import "http_handler" "add_header_value" (func $add_header_value
+    //   (param  $kind i32)
+    //   (param  $name i32) (param $name_len i32)
+    //   (param $value i32) (param $value_len i32)))
+
     unsafe {
         add_header_value(
             kind,
-            name.as_ptr(),
-            name.len() as u32,
-            value.as_ptr(),
-            value.len() as u32,
+            name.as_ptr() as *const i32,
+            name.len() as i32,
+            value.as_ptr() as *const i32,
+            value.len() as i32,
         )
     };
 }

--- a/forward-auth-wasm/src/guest.rs
+++ b/forward-auth-wasm/src/guest.rs
@@ -51,16 +51,16 @@ extern "C" {
         value_ptr: *const i32,
         value_len: i32,
     );
-    // TODO: implement
+    // working set_header_value
     fn set_header_value(
-        header_kind: u32,
-        name_ptr: *const u8,
-        name_len: u32,
-        value_ptr: *const u8,
-        value_len: u32,
+        header_kind: i32,
+        name_ptr: *const i32,
+        name_len: i32,
+        value_ptr: *const i32,
+        value_len: i32,
     );
-    // TODO: implement
-    fn remove_header(header_kind: u32, name_ptr: *const u8, name_len: u32);
+    // working remove_header
+    fn remove_header(header_kind: i32, name_ptr: *const i32, name_len: i32);
 
     // updated get_header_names signature
     fn get_header_names(header_kind: i32, buf: *const i32, buf_limit: i32) -> i64;
@@ -239,18 +239,35 @@ pub fn get_headers(kind: i32) -> Vec<String> {
     };
 }
 
-pub fn rem_header(kind: u32, name: &str) {
-    unsafe { remove_header(kind, name.as_ptr(), name.len() as u32) };
+pub fn rem_header(kind: i32, name: &str) {
+    // ;; remove_header removes all values for a header with the given name.
+    // ;;
+    // ;; Note: A host who fails to remove the header will trap (aka panic,
+    // ;; "unreachable" instruction).
+    // (import "http_handler" "remove_header" (func $set_header_value
+    //   (param  $kind i32)
+    //   (param  $name i32) (param $name_len i32)))
+
+    unsafe { remove_header(kind, name.as_ptr() as *const i32, name.len() as i32) };
 }
 
-pub fn set_header(kind: u32, name: &str, value: &str) {
+pub fn set_header(kind: i32, name: &str, value: &str) {
+    // ;; set_header_value overwrites all values of the given header name with the
+    // ;; input.
+    // ;;
+    // ;; Note: A host who fails to set the header will trap (aka panic,
+    // ;; "unreachable" instruction).
+    // (import "http_handler" "set_header_value" (func $set_header_value
+    //   (param  $kind i32)
+    //   (param  $name i32) (param $name_len i32)
+    //   (param $value i32) (param $value_len i32)))
     unsafe {
         set_header_value(
             kind,
-            name.as_ptr(),
-            name.len() as u32,
-            value.as_ptr(),
-            value.len() as u32,
+            name.as_ptr() as *const i32,
+            name.len() as i32,
+            value.as_ptr() as *const i32,
+            value.len() as i32,
         )
     };
 }

--- a/forward-auth-wasm/src/lib.rs
+++ b/forward-auth-wasm/src/lib.rs
@@ -33,14 +33,13 @@ pub fn http_request() -> i64 {
     // let header_values = &guest::get_header_val(guest::REQUEST_HEADER, &header);
     // guest::send_log(guest::DEBUG, format!("{:?}", header_values).as_str());
 
-    // let data = &guest::readbody(REQUEST_BODY);
-    let features = &guest::enable_feature(guest::FEATURE_BUFFER_REQUEST);
-    guest::send_log(guest::WARN, format!("{:?}", features).as_str());
-
+    // guest::send_log(guest::WARN, format!("{:?}", features).as_str());
+    guest::add_header(guest::RESPONSE_HEADER, "X-DEAD-BEEF", "Bearer 123456789");
     return 16 << 32 | 1 as i64;
 }
 
 #[export_name = "handle_response"]
 fn http_response(_req_ctx: i32, _is_error: i32) {
-    guest::send_log(guest::INFO, format!("{:?}", _req_ctx).as_str())
+
+    // guest::send_log(guest::INFO, format!("{:?}", _req_ctx).as_str())
 }

--- a/forward-auth-wasm/src/lib.rs
+++ b/forward-auth-wasm/src/lib.rs
@@ -34,7 +34,7 @@ pub fn http_request() -> i64 {
     // guest::send_log(guest::DEBUG, format!("{:?}", header_values).as_str());
 
     // guest::send_log(guest::WARN, format!("{:?}", features).as_str());
-    guest::add_header(guest::RESPONSE_HEADER, "X-DEAD-BEEF", "Bearer 123456789");
+    guest::rem_header(guest::REQUEST_HEADER, "cookie");
     return 16 << 32 | 1 as i64;
 }
 


### PR DESCRIPTION
This pull request includes changes to the `forward-auth-wasm` project, focusing on updating function signatures and improving logging and header manipulation. The most important changes include modifying function parameter types, updating function implementations, and cleaning up log statements.

### Function Signature Updates:

* Updated the parameter types for `add_header_value`, `set_header_value`, and `remove_header` functions from `u32` to `i32` in `extern "C"` block.

### Function Implementation Updates:

* Changed the `kind` parameter type from `u32` to `i32` in the `rem_header`, `set_header`, and `add_header` functions and updated their unsafe calls accordingly in `forward-auth-wasm/src/guest.rs`.

### Logging and Header Manipulation:

* Removed a log statement and added a call to `rem_header` to remove the "cookie" header in the `http_request` function in `forward-auth-wasm/src/lib.rs`.