### PR TITLE
added set_request_message

### DIFF
--- a/forward-auth-wasm/src/guest.rs
+++ b/forward-auth-wasm/src/guest.rs
@@ -35,12 +35,12 @@ extern "C" {
     fn get_config(buf: *const i32, buf_limit: i32) -> i32;
     // working with get_method
     fn get_method(buf: *const i32, buf_limit: i32) -> i32;
-    // TODO: implement
-    fn set_method(ptr: *const u8, message_len: u32);
+    // working set_method
+    fn set_method(ptr: *const i32, message_len: i32);
     // working with get_uri
     fn get_uri(ptr: *const i32, message_len: i32) -> i32;
-    // TODO: implement
-    fn set_uri(ptr: *const u8, message_len: u32);
+    // working set_uri
+    fn set_uri(ptr: *const i32, message_len: i32);
     // working get_protocol_version
     fn get_protocol_version(ptr: *const i32, message_len: i32) -> i32;
     // working add_header_value
@@ -371,7 +371,13 @@ pub fn get_request_method() -> String {
 }
 
 pub fn set_request_method(method: &str) {
-    unsafe { set_method(method.as_ptr(), method.len() as u32) };
+    // ;; set_method overwrites the method with one read from memory, e.g. "POST".
+    // ;;
+    // ;; Note: A host who fails to set the method will trap (aka panic, "unreachable"
+    // ;; instruction).
+    // (import "http_handler" "set_method" (func $set_method
+    //   (param $method i32) (param $method_len i32)))
+    unsafe { set_method(method.as_ptr() as *const i32, method.len() as i32) };
 }
 
 pub fn get_request_uri() -> String {
@@ -400,7 +406,18 @@ pub fn get_request_uri() -> String {
 }
 
 pub fn set_request_uri(uri: &str) {
-    unsafe { set_uri(uri.as_ptr(), uri.len() as u32) };
+    // ;; set_uri overwrites the URI with one read from memory, e.g.
+    // ;; "/v1.0/hi?name=panda".
+    // ;;
+    // ;; Note: The URI may include query parameters. The guest MUST pass
+    // ;; the URI encoded as the host will ALWAYS expect the URI as encoded
+    // ;; and passing it unencoded could lead to unexpected behaviours.
+    // ;;
+    // ;; Note: A host who fails to set the URI will trap (aka panic, "unreachable"
+    // ;; instruction).
+    // (import "http_handler" "set_uri" (func $set_uri
+    //   (param $uri i32) (param $uri_len i32)))
+    unsafe { set_uri(uri.as_ptr() as *const i32, uri.len() as i32) };
 }
 
 pub fn get_request_protocol_version() -> String {

--- a/forward-auth-wasm/src/lib.rs
+++ b/forward-auth-wasm/src/lib.rs
@@ -34,7 +34,7 @@ pub fn http_request() -> i64 {
     // guest::send_log(guest::DEBUG, format!("{:?}", header_values).as_str());
 
     // guest::send_log(guest::WARN, format!("{:?}", features).as_str());
-    guest::rem_header(guest::REQUEST_HEADER, "cookie");
+    guest::set_request_method("POST");
     return 16 << 32 | 1 as i64;
 }
 


### PR DESCRIPTION
This pull request includes changes to the `forward-auth-wasm` project, focusing on updating the method and URI handling in the guest module. The changes involve modifying the function signatures and adding detailed comments to clarify the behavior of the `set_method` and `set_uri` functions.

Updates to method and URI handling:

* [`forward-auth-wasm/src/guest.rs`](diffhunk://#diff-a05cca784d0cf768c7daea9427a9565f0ed99e6660d62b9a579a0059c7ebc94eL38-R43): Updated the function signatures for `set_method` and `set_uri` to use `i32` instead of `u8` for the pointer parameters. Added detailed comments explaining the behavior and expectations for these functions. [[1]](diffhunk://#diff-a05cca784d0cf768c7daea9427a9565f0ed99e6660d62b9a579a0059c7ebc94eL38-R43) [[2]](diffhunk://#diff-a05cca784d0cf768c7daea9427a9565f0ed99e6660d62b9a579a0059c7ebc94eL374-R380) [[3]](diffhunk://#diff-a05cca784d0cf768c7daea9427a9565f0ed99e6660d62b9a579a0059c7ebc94eL403-R420)

Additional change:

* [`forward-auth-wasm/src/lib.rs`](diffhunk://#diff-3be3d7e5b2acc1cbf69896093481cf13a79f2b3ac1943779779fec6275838a35L37-R37): Added a call to `set_request_method("POST")` in the `http_request` function to set the request method to "POST".