### PR TITLE
Dev/is log enabled

### DIFF
--- a/forward-auth-wasm/src/guest.rs
+++ b/forward-auth-wasm/src/guest.rs
@@ -145,6 +145,15 @@ pub fn readbody(kind: i32) -> Vec<u8> {
 }
 
 pub fn set_code(code: i32) {
+    // ;; set_status_code overwrites the status code produced by the next handler defined
+    // ;; on the host, e.g. 200. To call this in `handle_response` requires
+    // ;;`feature_buffer_response`.
+    // ;;
+    // ;; Note: A host who fails to set the status code will trap (aka panic,
+    // ;; "unreachable" instruction).
+    // (import "http_handler" "set_status_code" (func $set_status_code
+    //   (param $status_code i32)))
+
     unsafe { set_status_code(code) };
 }
 

--- a/forward-auth-wasm/src/guest.rs
+++ b/forward-auth-wasm/src/guest.rs
@@ -30,7 +30,7 @@ pub struct CloudflareConfig {
 #[link(wasm_import_module = "http_handler")]
 extern "C" {
     // working with log
-    fn log(level: i32, message: *const u8, message_len: u32);
+    fn log(level: i32, message: *const i32, message_len: i32);
     // working with get_config
     fn get_config(buf: *const i32, buf_limit: i32) -> i32;
     // working with get_method
@@ -75,7 +75,7 @@ extern "C" {
         buf_limit: i32,
     ) -> i64;
 
-    // TODO: implement
+    // log_enabled working
     fn log_enabled(level: i32) -> i32;
 
     // read_body working
@@ -152,7 +152,12 @@ pub fn writebody(kind: u32, message: &str) {
     unsafe { write_body(kind, message.as_ptr(), message.len() as u32) };
 }
 
-pub fn log_enabl(level: i32) -> i32 {
+pub fn is_log_enabled(level: i32) -> i32 {
+    // ;; log_enabled returns 1 if the $level is enabled. This value may be cached
+    // ;; at request granularity.
+    // (import "http_handler" "log_enabled" (func $log_enabled
+    //   (param $level i32)
+    //   (result (; 0 or enabled(1) ;) i32)))
     unsafe {
         match log_enabled(level) {
             res => return res,
@@ -294,7 +299,15 @@ pub fn add_header(kind: i32, name: &str, value: &str) {
 }
 
 pub fn send_log(level: i32, message: &str) {
-    unsafe { log(level, message.as_ptr(), message.len() as u32) };
+    // ;; log adds a UTF-8 encoded message to the host's logs at the given $level.
+    // ;;
+    // ;; Note: A host who fails to log a message should ignore it instead of a trap
+    // ;; (aka panic, "unreachable" instruction).
+    // (import "http_handler" "log" (func $log
+    //   (param $level (; log_level ;) i32)
+    //   (param $message i32) (param $message_len i32)))
+
+    unsafe { log(level, message.as_ptr() as *const i32, message.len() as i32) };
 }
 
 pub fn get_conf() -> Vec<u8> {

--- a/forward-auth-wasm/src/lib.rs
+++ b/forward-auth-wasm/src/lib.rs
@@ -34,20 +34,8 @@ pub fn http_request() -> i64 {
     // guest::send_log(guest::DEBUG, format!("{:?}", header_values).as_str());
 
     // guest::send_log(guest::WARN, format!("{:?}", features).as_str());
-    let debug = guest::is_log_enabled(guest::DEBUG);
-    let info = guest::is_log_enabled(guest::INFO);
-    let warn = guest::is_log_enabled(guest::WARN);
-    let fatal = guest::is_log_enabled(guest::FATAL);
-    let error = guest::is_log_enabled(guest::ERROR);
 
-    guest::send_log(
-        guest::DEBUG,
-        format!(
-            "Debug: {} Info: {} Warn: {} Fatal: {}, Error: {}",
-            debug, info, warn, fatal, error
-        )
-        .as_str(),
-    );
+    guest::set_code(404);
 
     return 16 << 32 | 1 as i64;
 }

--- a/forward-auth-wasm/src/lib.rs
+++ b/forward-auth-wasm/src/lib.rs
@@ -34,7 +34,21 @@ pub fn http_request() -> i64 {
     // guest::send_log(guest::DEBUG, format!("{:?}", header_values).as_str());
 
     // guest::send_log(guest::WARN, format!("{:?}", features).as_str());
-    guest::set_request_method("POST");
+    let debug = guest::is_log_enabled(guest::DEBUG);
+    let info = guest::is_log_enabled(guest::INFO);
+    let warn = guest::is_log_enabled(guest::WARN);
+    let fatal = guest::is_log_enabled(guest::FATAL);
+    let error = guest::is_log_enabled(guest::ERROR);
+
+    guest::send_log(
+        guest::DEBUG,
+        format!(
+            "Debug: {} Info: {} Warn: {} Fatal: {}, Error: {}",
+            debug, info, warn, fatal, error
+        )
+        .as_str(),
+    );
+
     return 16 << 32 | 1 as i64;
 }
 


### PR DESCRIPTION
This pull request includes multiple changes to the `forward-auth-wasm/src/guest.rs` file, focusing on improving logging functionality, adding comments for clarity, and modifying function signatures. Additionally, there is a minor change in `forward-auth-wasm/src/lib.rs` to set a response code.

### Logging and Function Signature Changes:

* Changed the `log` function's parameters to use `i32` for `message` and `message_len` instead of `u8` and `u32`, respectively.
* Updated the `send_log` function to use the new `log` function signature and added comments explaining the behavior of the `log` function.

### Comment Additions and Clarifications:

* Added comments to the `set_code` function to explain the behavior and requirements of the `set_status_code` function.
* Added comments to the `is_log_enabled` function to clarify the return value and its caching behavior.

### Minor Functional Change:

* Modified the `http_request` function in `forward-auth-wasm/src/lib.rs` to set the response code to 404.